### PR TITLE
remove build examples from the build pipeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start:prod": "cross-env NODE_ENV=production node index.js",
     "lint": "eslint client server --ext .jsx --ext .js",
     "lint-fix": "eslint client server --ext .jsx --ext .js --fix",
-    "build": "npm run build:client && npm run build:server && npm run build:examples",
+    "build": "npm run build:client && npm run build:server",
     "build:client": "cross-env NODE_ENV=production webpack --config webpack/config.prod.js",
     "build:server": "cross-env NODE_ENV=production webpack --config webpack/config.server.js",
     "build:examples": "cross-env NODE_ENV=production webpack --config webpack/config.examples.js",


### PR DESCRIPTION
Per #19 this remove the build examples from the build pipeline. I think the examples aren't actually used anywhere right now (as they aren't wired up to anything). Thus this shouldn't affect anything, just improve the speed of the builds. 