### PR TITLE
more strongly activate the linter

### DIFF
--- a/client/modules/IDE/components/Editor.jsx
+++ b/client/modules/IDE/components/Editor.jsx
@@ -76,7 +76,7 @@ class Editor extends React.Component {
     this.justTidied = false;
 
     this.updateLintingMessageAccessibility = debounce((annotations) => {
-      this.props.clearLintMessage();
+      console.log(annotations);
       annotations.forEach((x) => {
         if (x.from.line > -1) {
           this.props.updateLintMessage(x.severity, x.from.line + 1, x.message);
@@ -113,13 +113,9 @@ class Editor extends React.Component {
       autoCloseBrackets: this.props.autocloseBracketsQuotes,
       styleSelectedText: true,
       lint: {
-        onUpdateLinting: (annotations) => {
-          this.props.hideRuntimeErrorWarning();
-          this.updateLintingMessageAccessibility(annotations);
-        },
         options: {
-          asi: true,
-          eqeqeq: false,
+          // asi: true,
+          eqeqeq: true,
           '-W041': false,
           esversion: 7
         }

--- a/client/styles/components/_editor.scss
+++ b/client/styles/components/_editor.scss
@@ -30,17 +30,10 @@ pre.CodeMirror-line {
   bottom: 0;
 }
 
-.CodeMirror-lint-marker-warning, .CodeMirror-lint-marker-error, .CodeMirror-lint-marker-multiple {
-  background-image: none;
-  width: #{49 / $base-font-size}rem;
-  position: absolute;
-  height: 100%;
-  right: 100%;
-}
 
 .CodeMirror-lint-message-error, .CodeMirror-lint-message-warning {
-  background-image: none;
-  padding-left: inherit;
+  // padding-left: inherit;
+  padding-left: 20px;
 }
 
 .CodeMirror-lint-marker-warning {


### PR DESCRIPTION
It turns out this editor already comes with a somewhat crummy usage of jshint (which is an okay linter, but hardly the state of the art). This PR addresses #48 by just making the lints more apparent. 