### PR TITLE
Make log times human readable

### DIFF
--- a/server/controllers/project.controller.js
+++ b/server/controllers/project.controller.js
@@ -287,7 +287,16 @@ export function downloadProjectAsZip(req, res) {
 }
 
 export function createLogItem(props) {
-  const { logType, projectId, projectFiles, projectName, userAgent, timestamp, username, callback = () => {} } = props;
+  const {
+    logType,
+    projectId,
+    projectFiles,
+    projectName,
+    userAgent,
+    timestamp,
+    username,
+    callback = () => {}
+  } = props;
 
   LogItem.create(
     {
@@ -299,9 +308,8 @@ export function createLogItem(props) {
         projectName,
         files: projectFiles
       },
-      // https://mongoosejs.com/docs/guide.html#timestamps
-      // Make Mongoose use Unix time (seconds since Jan 1, 1970)
-      createdAt: Math.floor(timestamp / 1000)
+      createdAt: new Date(timestamp),
+      updatedAt: new Date(timestamp)
     },
     (createLogItemErr, logItem) => {
       if (createLogItemErr) {

--- a/server/models/logItem.js
+++ b/server/models/logItem.js
@@ -28,7 +28,7 @@ const logItemSchema = new Schema(
       type: String
     },
     createdAt: {
-      type: Number
+      type: Date
     },
     projectSnapshot: { type: projectSnapshotSchema }
   },


### PR DESCRIPTION
#75 
It's important for us to be able to read the logs well. This fixes an issue with the updated date being at the start of epoch and swaps epoch time for javascript date