### PR TITLE
Adjust color of loop button

### DIFF
--- a/client/modules/IDE/components/Toolbar.jsx
+++ b/client/modules/IDE/components/Toolbar.jsx
@@ -122,12 +122,13 @@ class Toolbar extends React.Component {
           </button>
           <button
             className={autoRefreshButtonClass}
-            onClick={() => {
+            onClick={(e) => {
               setGlobalTrack('liveMode', !this.props.autorefresh);
               trackEvent({
                 eventName: this.props.autorefresh ? 'autorefresh-stop' : 'autorefresh-start'
               });
               this.props.setAutorefresh(!this.props.autorefresh);
+              e.currentTarget.blur();
             }}
             aria-label={this.props.t('Toolbar.Auto-refresh')}
           >

--- a/client/styles/components/_toolbar.scss
+++ b/client/styles/components/_toolbar.scss
@@ -35,8 +35,7 @@
 .toolbar__play-sketch-button {
 	@extend %hidden-element;
 }
-.toolbar__stop-button,
-.toolbar__autorefresh-button {
+.toolbar__stop-button {
 	@include themify() {
 		@extend %toolbar-button;
 		display: flex;
@@ -46,6 +45,40 @@
 		padding: 0;
 		&--selected {
 			@extend %toolbar-button--selected;
+		}
+	}
+	span {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		width: #{20 / $base-font-size}rem;
+		height: #{20 / $base-font-size}rem;
+	}
+}
+
+.toolbar__autorefresh-button {
+	@include themify() {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		margin-right: #{15 / $base-font-size}rem;
+		padding: 0;
+		
+		& g, & path {
+			fill: getThemifyVariable('button-color');
+		}
+		&--selected, 
+		&--selected:hover {
+			& g, & path {
+				fill: getThemifyVariable('button-background-hover-color');
+			}
+		}
+		&:hover {
+			opacity: 0.5;
+		}
+		&:focus {
+			outline: none;
+			box-shadow: none;
 		}
 	}
 	span {


### PR DESCRIPTION
#133
Looping off
<img width="383" alt="Screen Shot 2022-01-10 at 10 40 16 AM" src="https://user-images.githubusercontent.com/6854312/148803462-864915eb-a7d0-40f6-b9b4-dc91eca3a19a.png">

Looping on
<img width="429" alt="Screen Shot 2022-01-10 at 10 40 19 AM" src="https://user-images.githubusercontent.com/6854312/148803465-cd4ab3ce-78b2-4fa7-aee5-851a332384c6.png">

Loop button hovered
<img width="434" alt="Screen Shot 2022-01-10 at 10 40 23 AM" src="https://user-images.githubusercontent.com/6854312/148803468-ab50e3cc-6e9e-419f-b358-2e748438c890.png">
 